### PR TITLE
Initial bundle deserialization

### DIFF
--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
 
 /// Bundle implements a CNAB bundle descriptor
 ///
@@ -18,7 +20,7 @@ pub struct Bundle {
     /// The list of configurable credentials.
     ///
     /// Credentials are injected into the bundle's invocation image at startup time.
-    pub credentials: Option<Vec<Credential>>,
+    pub credentials: Option<HashMap<String, Credential>>,
     /// This field allows for additional data to described in the bundle.
     ///
     /// This data should be stored in key/value pairs, where the value is undefined by
@@ -58,6 +60,12 @@ impl Bundle {
     ///fn new(name: String, version: String) -> Bundle {}
     pub fn from_string(json_data: &str) -> Result<Bundle, serde_json::Error> {
         let res: Bundle = serde_json::from_str(json_data)?;
+        Ok(res)
+    }
+
+    pub fn from_file(file_path: &str) -> Result<Bundle, serde_json::Error> {
+        let file = File::open(Path::new(&file_path)).expect("file not found");
+        let res: Bundle = serde_json::from_reader(file)?;
         Ok(res)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -48,7 +48,6 @@ fn test_bundle_keywords() {
 
 #[test]
 fn test_bundle_parameters() {
-    // Testing that we can build one with only the minimal fields.
     let res = Bundle::from_string(
         r#"{
         "name": "aristotle",
@@ -172,4 +171,15 @@ fn test_bundle_images() {
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
     assert_that(&bun.version).is_equal_to("1.0.0".to_string());
     assert_that(&bun.invocation_images.len()).is_equal_to(&1);
+}
+
+#[test]
+fn test_bundle_deserialize() {
+    let bun = Bundle::from_file("testdata/bundle.json").unwrap();
+
+    assert_that(&bun.name).is_equal_to("helloworld".to_string());
+    assert_that(&bun.schema_version).is_equal_to("v1.0.0-WD".to_string());
+    assert_that(&bun.version).is_equal_to("0.1.2".to_string());
+    assert_that(&bun.maintainers.unwrap().len()).is_equal_to(&1);
+    assert_that(&bun.custom.unwrap().len()).is_equal_to(&2);
 }

--- a/testdata/bundle.json
+++ b/testdata/bundle.json
@@ -1,0 +1,56 @@
+{
+    "credentials": {
+        "hostkey": {
+            "env": "HOST_KEY",
+            "path": "/etc/hostkey.txt"
+        }
+    },
+    "custom": {
+        "com.example.backup-preferences": {
+            "frequency": "daily"
+        },
+        "com.example.duffle-bag": {
+            "icon": "https://example.com/icon.png",
+            "iconType": "PNG"
+        }
+    },
+    "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
+    "images": {
+        "my-microservice": {
+            "description": "my microservice",
+            "digest": "sha256:aaaaaaaaaaaa...",
+            "image": "technosophos/microservice:1.2.3"
+        }
+    },
+    "invocationImages": [
+        {
+            "digest": "sha256:aaaaaaa...",
+            "image": "technosophos/helloworld:0.1.0",
+            "imageType": "docker"
+        }
+    ],
+    "maintainers": [
+        {
+            "email": "matt.butcher@microsoft.com",
+            "name": "Matt Butcher",
+            "url": "https://example.com"
+        }
+    ],
+    "name": "helloworld",
+    "parameters": {
+        "backend_port": {
+            "defaultValue": 80,
+            "destination": {
+                "env": "BACKEND_PORT"
+            },
+            "maxValue": 10240,
+            "metadata": {
+                "description": "The port that the back-end will listen on"
+            },
+            "minValue": 10,
+            "type": "int"
+        }
+    },
+    "schemaVersion": "v1.0.0-WD",
+    "version": "0.1.2"
+}


### PR DESCRIPTION
depends on #1 

This PR:

- updates the `custom` property in `Bundle` from a `Vector` to `HashMap` (bundles wouldn't deserialize)
- adds example `bundle.json` file in `testdata`
- adds `test_bundle_deserialize` test function
- adds `Bundle::from_file` function

We should add some more testing, thus leaving this PR as draft.