### PR TITLE
Change all Strings in Bundle structs to str

### DIFF
--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -9,54 +9,54 @@ use std::collections::HashMap;
 /// The fields here are in canonical order.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Bundle {
+pub struct Bundle<'a> {
     /// The list of additional actions that this bundle can perform.
     ///
     /// 'install', 'upgrade', and 'uninstall' are default actions, but additional actions
     /// may be defined here.
-    pub actions: Option<HashMap<String, Action>>,
+    pub actions: Option<HashMap<&'a str, Action<'a>>>,
     /// The list of configurable credentials.
     ///
     /// Credentials are injected into the bundle's invocation image at startup time.
-    pub credentials: Option<Vec<Credential>>,
+    pub credentials: Option<Vec<Credential<'a>>>,
     /// This field allows for additional data to described in the bundle.
     ///
     /// This data should be stored in key/value pairs, where the value is undefined by
     /// the specification (but must be representable as JSON).
-    pub custom: Option<HashMap<String, serde_json::Value>>,
+    pub custom: Option<HashMap<&'a str, serde_json::Value>>,
     /// description is a short description of this bundle
-    pub description: Option<String>,
+    pub description: Option<&'a str>,
     /// The list of images that comprise this bundle.
     ///
     /// Each image here is considered a constituent of the application described by this
     /// bundle.
-    pub images: Option<HashMap<String, Image>>,
+    pub images: Option<HashMap<&'a str, Image<'a>>>,
     /// inovcation_images is the list of available bootstrapping images for this bundle
     ///
     /// Only one ought to be executed.
-    pub invocation_images: Vec<Image>,
+    pub invocation_images: Vec<Image<'a>>,
     /// keywords is a list of keywords describing this bundle
-    pub keywords: Option<Vec<String>>,
+    pub keywords: Option<Vec<&'a str>>,
     /// license is the license of this bundle
-    pub license: Option<String>,
+    pub license: Option<&'a str>,
     /// maintainers is a list of maintainers responsible for this bundle
-    pub maintainers: Option<Vec<Maintainer>>,
+    pub maintainers: Option<Vec<Maintainer<'a>>>,
     /// name is the name of the bundle
-    pub name: String,
+    pub name: &'a str,
     /// The collection of parameters that can be passed into this bundle.
     ///
     /// Parameters can be injected into a bundle during startup time.
-    pub parameters: Option<HashMap<String, Parameter>>,
+    pub parameters: Option<HashMap<&'a str, Parameter<'a>>>,
     /// schema_version is the version of the CNAB specification used to describe this
-    pub schema_version: String,
+    pub schema_version: &'a str,
     /// version is the version of the bundle
-    pub version: String,
+    pub version: &'a str,
 }
 
 /// Represents a bundle.
-impl Bundle {
+impl<'a> Bundle<'a> {
     ///fn new(name: String, version: String) -> Bundle {}
-    pub fn from_string(json_data: &str) -> Result<Bundle, serde_json::Error> {
+    pub fn from_string(json_data: &'a str) -> Result<Bundle<'a>, serde_json::Error> {
         let res: Bundle = serde_json::from_str(json_data)?;
         Ok(res)
     }
@@ -66,13 +66,13 @@ impl Bundle {
 ///
 /// The name field is required, though the format of its value is unspecified.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Maintainer {
+pub struct Maintainer<'a> {
     /// The email address of the maintainer
-    pub email: Option<String>,
+    pub email: Option<&'a str>,
     /// The name of the maintainer
-    pub name: String,
+    pub name: &'a str,
     /// A URL with more information about the maintainer
-    pub url: Option<String>,
+    pub url: Option<&'a str>,
 }
 
 /// Image describes a CNAB image.
@@ -80,43 +80,43 @@ pub struct Maintainer {
 /// Both invocation images and regular images can be described using this object.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Image {
+pub struct Image<'a> {
     /// A digest to be used to verify the integrity of the image
-    pub digest: Option<String>,
+    pub digest: Option<&'a str>,
     /// The image, as a string of the form REPO/NAME:TAG@SHA
-    pub image: String,
+    pub image: &'a str,
     /// The type of image. Typically, this is treated as an OCI Image
-    pub image_type: Option<String>,
+    pub image_type: Option<&'a str>,
     /// The media type of the image
-    pub media_type: Option<String>,
+    pub media_type: Option<&'a str>,
     /// The platform this image may be deployed on
-    pub platform: Option<Platform>,
+    pub platform: Option<Platform<'a>>,
     /// The size in bytes of the image
     pub size: Option<i64>,
 }
 
 /// Platform defines a platform as a machine architecture plus and operating system
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Platform {
+pub struct Platform<'a> {
     /// The architecture
     ///
     /// Typical values are amd64, i386, and arm64
-    pub arch: Option<String>,
+    pub arch: Option<&'a str>,
     /// The operating system.
     ///
     /// Typical values are darwin, windows, and linux
-    pub os: Option<String>,
+    pub os: Option<&'a str>,
 }
 
 /// Credential describes a particular credential that may be injected into a bundle
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Credential {
+pub struct Credential<'a> {
     /// The description of this credential
-    pub description: Option<String>,
+    pub description: Option<&'a str>,
     /// The name of the environment variable into which the value will be placed
-    pub env: Option<String>,
+    pub env: Option<&'a str>,
     /// The fully qualified path into which the value will be placed
-    pub path: Option<String>,
+    pub path: Option<&'a str>,
 }
 
 /// Parameter describes a parameter that will be put into the invocation image
@@ -124,13 +124,13 @@ pub struct Credential {
 /// Paramters are injected into the invocation image at startup time
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Parameter {
+pub struct Parameter<'a> {
     /// The actions to which this parameter applies.
     ///
     /// If unset, this parameter will be applied to all actions.
-    pub apply_to: Option<Vec<String>>,
+    pub apply_to: Option<Vec<&'a str>>,
     /// The location where this parameter will be injected in the invocation image
-    pub destination: Destination,
+    pub destination: Destination<'a>,
     /// This parameter's default value
     pub default_value: Option<serde_json::Value>,
 
@@ -155,7 +155,7 @@ pub struct Parameter {
     /// If unspecified, no max is applied.
     pub max_length: Option<i64>,
     /// Additional parameter information
-    pub metadata: Option<Metadata>,
+    pub metadata: Option<Metadata<'a>>,
     /// The minimum integer value
     ///
     /// If unspecified, the minimum 64-bit integer value is applied
@@ -165,7 +165,7 @@ pub struct Parameter {
     /// A regular expression (as defined in ECMAScript)
     ///
     /// If it is not matched, a string parameter value will be rejected
-    pub pattern: Option<String>,
+    pub pattern: Option<&'a str>,
     /// Indicate whether this parameter is required
     ///
     /// Default is false.
@@ -173,7 +173,7 @@ pub struct Parameter {
     pub required: bool,
     /// This describes the underlying type of the parameter (string, int...)
     #[serde(rename = "type")]
-    pub parameter_type: String, // Should be Enum; alphabetically, this is 'type'
+    pub parameter_type: &'a str, // Should be Enum; alphabetically, this is 'type'
 }
 
 /// An Action is a custom action in an invocation image.
@@ -181,9 +181,9 @@ pub struct Parameter {
 /// For example, an invocation image may provide help text by creating a 'help'
 /// action that, when triggered, prints help text to STDOUT.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Action {
+pub struct Action<'a> {
     /// Describes what this action does
-    pub description: Option<String>,
+    pub description: Option<&'a str>,
     /// If true, this action modifies the deployment, and should be tracked as a release.
     #[serde(default)]
     pub modifies: bool,
@@ -197,9 +197,9 @@ pub struct Action {
 
 /// Describe a parameter
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Metadata {
+pub struct Metadata<'a> {
     /// A description of a parameter
-    pub description: Option<String>,
+    pub description: Option<&'a str>,
 }
 
 /// Destination describes where, in the invocation image, a particular paramter value should be
@@ -209,9 +209,9 @@ pub struct Metadata {
 /// a particular location on the filesystem (`path`). This is a non-exclusive or, meaining
 /// that the same paramter can be written to both an env var and a path.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Destination {
+pub struct Destination<'a> {
     /// The name of the destination environment variable
-    pub env: Option<String>,
+    pub env: Option<&'a str>,
     /// The fully qualified path to the destination file
-    pub path: Option<String>,
+    pub path: Option<&'a str>,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,9 +18,9 @@ fn test_bundle_simple() {
 
     let bun = res.unwrap();
 
-    assert_that(&bun.name).is_equal_to("aristotle".to_string());
-    assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.name).is_equal_to("aristotle");
+    assert_that(&bun.schema_version).is_equal_to("1.0-WD");
+    assert_that(&bun.version).is_equal_to("1.0.0");
     assert_that(&bun.invocation_images.len()).is_equal_to(&0);
 }
 
@@ -39,16 +39,16 @@ fn test_bundle_keywords() {
 
     let bun = res.unwrap();
 
-    assert_that(&bun.name).is_equal_to("aristotle".to_string());
-    assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.name).is_equal_to("aristotle");
+    assert_that(&bun.schema_version).is_equal_to("1.0-WD");
+    assert_that(&bun.version).is_equal_to("1.0.0");
     assert_that(&bun.invocation_images.len()).is_equal_to(&0);
 
     let kw = &bun.keywords.unwrap();
     assert_that(&kw.len()).is_equal_to(&3);
-    assert_that(&kw[0]).is_equal_to("a".to_string());
-    assert_that(&kw[1]).is_equal_to("b".to_string());
-    assert_that(&kw[2]).is_equal_to("c".to_string());
+    assert_that(&kw[0]).is_equal_to("a");
+    assert_that(&kw[1]).is_equal_to("b");
+    assert_that(&kw[2]).is_equal_to("c");
 }
 
 #[test]
@@ -109,27 +109,27 @@ fn test_bundle_parameters() {
 
     let bun = res.unwrap();
 
-    assert_that(&bun.name).is_equal_to("aristotle".to_string());
-    assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.name).is_equal_to("aristotle");
+    assert_that(&bun.schema_version).is_equal_to("1.0-WD");
+    assert_that(&bun.version).is_equal_to("1.0.0");
 
     let params = bun.parameters.unwrap();
     assert_that(&params.len()).is_equal_to(&3);
 
-    let arg3 = params.get(&"arg3".to_string());
+    let arg3 = params.get(&"arg3");
 
     assert!(arg3.is_some());
-    assert_that(&arg3.unwrap().parameter_type).is_equal_to("string".to_string());
+    assert_that(&arg3.unwrap().parameter_type).is_equal_to("string");
 
     let apply = &arg3.unwrap().apply_to;
     assert!(apply.is_some());
 
     let dest = &arg3.unwrap().destination;
     let env = &dest.env;
-    assert_that(&env).is_equal_to(&Some("LETTERS".to_string()));
+    assert_that(&env).is_equal_to(&Some("LETTERS"));
 
     let path = &dest.path;
-    assert_that(path).is_equal_to(&Some("/path/to/abc".to_string()));
+    assert_that(path).is_equal_to(&Some("/path/to/abc"));
 
     let abc = json!("abc");
     let dv = &arg3.unwrap().default_value;
@@ -140,17 +140,17 @@ fn test_bundle_parameters() {
 
     assert_that(&arg3.as_ref().unwrap().min_length.unwrap()).is_equal_to(1);
     assert_that(&arg3.as_ref().unwrap().max_length.unwrap()).is_equal_to(5);
-    assert_that(&arg3.as_ref().unwrap().pattern).is_equal_to(&Some("[a-z]+".to_string()));
+    assert_that(&arg3.as_ref().unwrap().pattern).is_equal_to(&Some("[a-z]+"));
     assert_that(&arg3.unwrap().required).is_equal_to(true);
 
     let meta = &arg3.unwrap().metadata;
     assert_that(&meta.is_some()).is_equal_to(true);
 
-    assert_that(&meta.as_ref().unwrap().description.as_ref().unwrap()).is_equal_to(&"a parameter".to_string());
+    assert_that(&meta.as_ref().unwrap().description.as_ref().unwrap()).is_equal_to(&"a parameter");
 
     let apply_to = &arg3.unwrap().apply_to;
-    assert_that(apply_to).is_equal_to(&Some(vec!["uninstall".to_string()]));
-    assert_that(&arg3.unwrap().parameter_type).is_equal_to("string".to_string());
+    assert_that(apply_to).is_equal_to(&Some(vec!["uninstall"]));
+    assert_that(&arg3.unwrap().parameter_type).is_equal_to("string");
 }
 
 #[test]
@@ -191,8 +191,8 @@ fn test_bundle_images() {
 
     let bun = res.unwrap();
 
-    assert_that(&bun.name).is_equal_to("aristotle".to_string());
-    assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.name).is_equal_to("aristotle");
+    assert_that(&bun.schema_version).is_equal_to("1.0-WD");
+    assert_that(&bun.version).is_equal_to("1.0.0");
     assert_that(&bun.invocation_images.len()).is_equal_to(&1);
 }


### PR DESCRIPTION
Really cool project! I was introduced to this by @scotty-c.

This change moves all of Bundle's (and its related structs') Strings to be &str constrained on some lifetime `'a` which when deserializing will be the lifetime of the json `str`. This cuts down massively on the number of allocations needed to deserialize Bundles. It does mean though that you'll have the noise of having to mess with lifetime params when working with `Bundle` and its related structs. 