### PR TITLE
Add initial canonical JSON serializer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ keywords = ["cnab"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-semver = { version = "0.9", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+canonical_json = { git = "https://github.com/engineerd/canonical_json" }
+serde = "0.8"
+serde_derive = "0.8"
+serde_json = "0.8"
 spectral = "0.6"
 
 [dev-dependencies]

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -1,6 +1,6 @@
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::btree_map::BTreeMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -20,24 +20,24 @@ pub struct Bundle {
     ///
     /// 'install', 'upgrade', and 'uninstall' are default actions, but additional actions
     /// may be defined here.
-    pub actions: Option<HashMap<String, Action>>,
+    pub actions: Option<BTreeMap<String, Action>>,
     /// The list of configurable credentials.
     ///
     /// Credentials are injected into the bundle's invocation image at startup time.
-    pub credentials: Option<HashMap<String, Credential>>,
+    pub credentials: Option<BTreeMap<String, Credential>>,
     /// This field allows for additional data to described in the bundle.
     ///
     /// This data should be stored in key/value pairs, where the value is undefined by
     /// the specification (but must be representable as JSON).
-    pub custom: Option<HashMap<String, serde_json::Value>>,
+    pub custom: Option<BTreeMap<String, serde_json::Value>>,
     /// description is a short description of this bundle
     pub description: Option<String>,
     /// The list of images that comprise this bundle.
     ///
     /// Each image here is considered a constituent of the application described by this
     /// bundle.
-    pub images: Option<HashMap<String, Image>>,
-    /// inovcation_images is the list of available bootstrapping images for this bundle
+    pub images: Option<BTreeMap<String, Image>>,
+    /// invocation_images is the list of available bootstrapping images for this bundle
     ///
     /// Only one ought to be executed.
     pub invocation_images: Vec<Image>,
@@ -52,7 +52,7 @@ pub struct Bundle {
     /// The collection of parameters that can be passed into this bundle.
     ///
     /// Parameters can be injected into a bundle during startup time.
-    pub parameters: Option<HashMap<String, Parameter>>,
+    pub parameters: Option<BTreeMap<String, Parameter>>,
     /// schema_version is the version of the CNAB specification used to describe this
     pub schema_version: String,
     /// version is the version of the bundle

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -1,8 +1,5 @@
-use semver::Version;
-use serde::{Deserialize, Serialize};
 use std::collections::btree_map::BTreeMap;
 use std::fs::File;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -14,7 +11,6 @@ use std::str::FromStr;
 ///
 /// The fields here are in canonical order.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Bundle {
     /// The list of additional actions that this bundle can perform.
     ///
@@ -40,6 +36,7 @@ pub struct Bundle {
     /// invocation_images is the list of available bootstrapping images for this bundle
     ///
     /// Only one ought to be executed.
+    #[serde(rename = "invocationImages")]
     pub invocation_images: Vec<Image>,
     /// keywords is a list of keywords describing this bundle
     pub keywords: Option<Vec<String>>,
@@ -54,9 +51,10 @@ pub struct Bundle {
     /// Parameters can be injected into a bundle during startup time.
     pub parameters: Option<BTreeMap<String, Parameter>>,
     /// schema_version is the version of the CNAB specification used to describe this
+    #[serde(rename = "schemaVersion")]
     pub schema_version: String,
     /// version is the version of the bundle
-    pub version: Version,
+    pub version: String,
 }
 
 /// Represents a bundle.
@@ -69,24 +67,64 @@ impl Bundle {
     /// let bundle = Bundle::from_file("testdata/bundle.json").unwrap();
     /// assert_eq!(bundle.name, "helloworld");
     /// ```
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, BundleParseError> {
-        let file = File::open(path)?;
-        Self::from_json(file)
-    }
-
-    /// Deserialize a `Bundle` from any type implementing `Read`.
-    pub fn from_json<R: Read>(reader: R) -> Result<Self, BundleParseError> {
-        let bundle = serde_json::from_reader(reader)?;
-        Ok(bundle)
+    pub fn from_file(file_path: &str) -> Result<Self, BundleParseError> {
+        let file = File::open(Path::new(&file_path))?;
+        let res: Result<Bundle, canonical_json::Error> = canonical_json::from_reader(file);
+        match res {
+            Ok(b) => Ok(b),
+            Err(err) => {
+                match err {
+                    // the canonical JSON parser errors out if the input JSON is not canonical
+                    // for now, we should accept non-canonical JSON as input
+                    canonical_json::Error::Syntax(
+                        canonical_json::SyntaxError::UnexpectedWhitespace,
+                        _,
+                        _,
+                    ) => {
+                        let file = File::open(Path::new(&file_path)).expect("file not found");
+                        let b: Result<Bundle, serde_json::Error> = serde_json::from_reader(file);
+                        match b {
+                            Ok(b) => return Ok(b),
+                            Err(err) => return Err(BundleParseError::from(err)),
+                        };
+                    }
+                    // TODO - Radu M - check other error types generated because JSON is not canonical
+                    _ => (),
+                }
+                Err(BundleParseError::from(err))
+            }
+        }
     }
 }
 
 impl FromStr for Bundle {
-    type Err = serde_json::Error;
+    type Err = BundleParseError;
 
-    fn from_str(json_data: &str) -> Result<Self, Self::Err> {
-        let bundle = serde_json::from_str(json_data)?;
-        Ok(bundle)
+    fn from_str(json_data: &str) -> Result<Bundle, BundleParseError> {
+        let bundle: Result<Bundle, canonical_json::Error> = canonical_json::from_str(json_data);
+        match bundle {
+            Ok(b) => Ok(b),
+            Err(err) => {
+                match err {
+                    // the canonical JSON parser errors out if the input JSON is not canonical
+                    // for now, we should accept non-canonical JSON as input
+                    canonical_json::Error::Syntax(
+                        canonical_json::SyntaxError::UnexpectedWhitespace,
+                        _,
+                        _,
+                    ) => {
+                        let b: Result<Bundle, serde_json::Error> = serde_json::from_str(json_data);
+                        match b {
+                            Ok(b) => return Ok(b),
+                            Err(err) => return Err(BundleParseError::from(err)),
+                        };
+                    }
+                    // TODO - Radu M - check other error types generated because JSON is not canonical
+                    _ => (),
+                }
+                Err(BundleParseError::from(err))
+            }
+        }
     }
 }
 
@@ -97,6 +135,7 @@ impl FromStr for Bundle {
 #[derive(Debug)]
 pub enum BundleParseError {
     SerdeJSONError(serde_json::Error),
+    CanonicalJSONError(canonical_json::Error),
     IoError(std::io::Error),
 }
 
@@ -109,6 +148,12 @@ impl From<std::io::Error> for BundleParseError {
 impl From<serde_json::Error> for BundleParseError {
     fn from(error: serde_json::Error) -> Self {
         BundleParseError::SerdeJSONError(error)
+    }
+}
+
+impl From<canonical_json::Error> for BundleParseError {
+    fn from(error: canonical_json::Error) -> Self {
+        BundleParseError::CanonicalJSONError(error)
     }
 }
 
@@ -129,15 +174,16 @@ pub struct Maintainer {
 ///
 /// Both invocation images and regular images can be described using this object.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Image {
     /// A digest to be used to verify the integrity of the image
     pub digest: Option<String>,
     /// The image, as a string of the form REPO/NAME:TAG@SHA
     pub image: String,
     /// The type of image. Typically, this is treated as an OCI Image
+    #[serde(rename = "imageType")]
     pub image_type: Option<String>,
     /// The media type of the image
+    #[serde(rename = "mediaType")]
     pub media_type: Option<String>,
     /// The platform this image may be deployed on
     pub platform: Option<Platform>,
@@ -173,15 +219,16 @@ pub struct Credential {
 ///
 /// Paramters are injected into the invocation image at startup time
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Parameter {
     /// The actions to which this parameter applies.
     ///
     /// If unset, this parameter will be applied to all actions.
+    #[serde(rename = "applyTo")]
     pub apply_to: Option<Vec<String>>,
     /// The location where this parameter will be injected in the invocation image
     pub destination: Destination,
     /// This parameter's default value
+    #[serde(rename = "defaultValue")]
     pub default_value: Option<serde_json::Value>,
 
     /// An enumeration of allowed values
@@ -191,10 +238,12 @@ pub struct Parameter {
     /// The exclusive maximum.
     ///
     /// If unspecified, no exclusive max is applied
+    #[serde(rename = "exclusiveMaximum")]
     pub exclusive_maximum: Option<i64>,
     /// The exclusive minimum.
     ///
     /// If unspecified, no exclusive min is applied
+    #[serde(rename = "exclusiveMinimum")]
     pub exclusive_minimum: Option<i64>,
     /// The maximum
     ///
@@ -203,6 +252,7 @@ pub struct Parameter {
     /// The maximum length of a string value
     ///
     /// If unspecified, no max is applied.
+    #[serde(rename = "maxLength")]
     pub max_length: Option<i64>,
     /// Additional parameter information
     pub metadata: Option<Metadata>,
@@ -211,6 +261,7 @@ pub struct Parameter {
     /// If unspecified, the minimum 64-bit integer value is applied
     pub minimum: Option<i64>,
     /// The minimum string length
+    #[serde(rename = "minLength")]
     pub min_length: Option<i64>,
     /// A regular expression (as defined in ECMAScript)
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,18 @@
-#![cfg_attr(test, deny(warnings))]
+#![cfg(test)]
 #![warn(rust_2018_idioms)]
 
 mod cnab;
 pub use crate::cnab::*;
+
+#[macro_use]
+extern crate serde;
+#[macro_use]
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate canonical_json;
+extern crate spectral;
 
 #[cfg(test)]
 mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,10 @@
 use crate::cnab::*;
-use semver::Version;
+
+#[macro_use]
+use serde::*;
+#[macro_use]
+use serde_derive::*;
+#[macro_use]
 use serde_json::*;
 use spectral::prelude::*;
 
@@ -17,7 +22,7 @@ fn test_bundle_simple() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
+    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
     assert_that(&bun.invocation_images.len()).is_equal_to(&0);
 }
 
@@ -36,7 +41,7 @@ fn test_bundle_keywords() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
+    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
     assert_that(&bun.invocation_images.len()).is_equal_to(&0);
 
     let kw = &bun.keywords.unwrap();
@@ -104,7 +109,7 @@ fn test_bundle_parameters() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
+    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
 
     let params = bun.parameters.unwrap();
     assert_that(&params.len()).is_equal_to(&3);
@@ -183,13 +188,16 @@ fn test_bundle_parameters() {
             .is_some()
             .is_equal_to("/path/to/abc".parse::<std::path::PathBuf>().unwrap());
 
-        let abc = json!("abc");
+        let abc = Value::String("abc".to_string());
         let dv = &arg3.unwrap().default_value;
         assert_that(dv).is_equal_to(&Some(abc));
 
         let allowed = &arg3.unwrap().allowed_values;
-        assert_that(allowed).is_equal_to(&Some(vec![json!("a"), json!("ab"), json!("abc")]));
-
+        assert_that(allowed).is_equal_to(&Some(vec![
+            Value::String("a".to_string()),
+            Value::String("ab".to_string()),
+            Value::String("abc".to_string()),
+        ]));
         assert_that(&arg3.as_ref().unwrap().min_length)
             .is_some()
             .is_equal_to(1);
@@ -331,7 +339,7 @@ fn test_bundle_images() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
+    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
 
     // Check that all of the fields unmarshaled correctly.
     let invo_imgs = &bun.invocation_images;
@@ -379,7 +387,7 @@ fn test_bundle_deserialize() {
 
     assert_that(&bun.name).is_equal_to("helloworld".to_string());
     assert_that(&bun.schema_version).is_equal_to("v1.0.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to(Version::new(0, 1, 2));
+    assert_that(&bun.version).is_equal_to("0.1.2".to_string());
     assert_that(&bun.maintainers.unwrap().len()).is_equal_to(&1);
     assert_that(&bun.custom.unwrap().len()).is_equal_to(&2);
 }


### PR DESCRIPTION
This PR introduces a canonical JSON serializer. However, there are a few drawbacks:

- it needs `serde` at v0.8 (compared to v1.0 that we used before). This means some handy features of `serde` won't be available -- most notably `json!` and `#[serde(rename_all = "camelCase")]`. Ideally, we could be able to upgrade `serde` to v1.0 for this library.

- to preserve the order of the objects in maps, this PR also switches all  maps from HashMap to BTreeMap -- and we should be aware of the performance impact of this change, but for relatively small objects, the impact should be minimal -- documentation [here](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html).



Thanks!