### PR TITLE
Fix edition idioms, rust fmt, and add cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["cnab"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spectral = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,17 @@
 [package]
 name = "libcnab"
 version = "0.1.0"
+license = "MIT"
 authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
 edition = "2018"
+description = "A Rust implementation of CNAB Core 1.0-WD"
+homepage = "https://cnab.io"
+readme = "README.md"
+repository = "https://github.com/deislabs/libcnab-rust"
+keywords = ["cnab"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 serde = "1.0"

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -78,7 +78,7 @@ impl Bundle {
 #[derive(Debug)]
 pub enum BundleParseError {
     SerdeJSONError(serde_json::Error),
-    IoError(std::io::Error)
+    IoError(std::io::Error),
 }
 
 impl From<std::io::Error> for BundleParseError {
@@ -88,12 +88,12 @@ impl From<std::io::Error> for BundleParseError {
 }
 
 impl From<serde_json::Error> for BundleParseError {
-    fn from(error: serde_json::Error) -> Self{
+    fn from(error: serde_json::Error) -> Self {
         BundleParseError::SerdeJSONError(error)
     }
 }
 
-/// Maintainer describes a bundle mainainer.
+/// Maintainer describes a bundle maintainer.
 ///
 /// The name field is required, though the format of its value is unspecified.
 #[derive(Debug, Serialize, Deserialize)]
@@ -179,7 +179,7 @@ pub struct Parameter {
     pub exclusive_minimum: Option<i64>,
     /// The maximum
     ///
-    /// If unspecieid, the maximum 64-bit integer value is applied
+    /// If unspecified, the maximum 64-bit integer value is applied
     pub maximum: Option<i64>,
     /// The maximum length of a string value
     ///
@@ -221,7 +221,7 @@ pub struct Action {
     /// If true, this action does not require any state information to be injected
     ///
     /// For example, printing help text does not require an installation, credentials,
-    /// or paramters.
+    /// or parameters.
     #[serde(default)]
     pub stateless: bool,
 }
@@ -233,11 +233,11 @@ pub struct Metadata {
     pub description: Option<String>,
 }
 
-/// Destination describes where, in the invocation image, a particular paramter value should be
+/// Destination describes where, in the invocation image, a particular parameter value should be
 /// placed.
 ///
 /// A parameter value can be placed into an environment variable (`env`) or a file at
-/// a particular location on the filesystem (`path`). This is a non-exclusive or, meaining
+/// a particular location on the filesystem (`path`). This is a non-exclusive or, meaning
 /// that the same paramter can be written to both an env var and a path.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Destination {

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(test, deny(warnings))]
 #![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate serde_derive;
-
 pub mod cnab;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-extern crate serde;
+#![cfg_attr(test, deny(warnings))]
+#![warn(rust_2018_idioms)]
+
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 
 pub mod cnab;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,3 @@
-extern crate spectral;
-
 use crate::cnab::Bundle;
 use serde_json::*;
 use spectral::prelude::*;
@@ -125,12 +123,18 @@ fn test_bundle_parameters() {
         assert_that(&arg1.unwrap().required).is_false();
 
         // Destination should have just env
-        assert_that(&arg1.unwrap().destination.env.as_ref()).is_some().is_equal_to(&"FIRST".to_string());
+        assert_that(&arg1.unwrap().destination.env.as_ref())
+            .is_some()
+            .is_equal_to(&"FIRST".to_string());
         assert_that(&arg1.unwrap().destination.path).is_none();
 
         // Test exclusive_min/max
-        assert_that(&arg1.unwrap().exclusive_minimum).is_some().is_equal_to(&123);
-        assert_that(&arg1.unwrap().exclusive_maximum).is_some().is_equal_to(&567789);
+        assert_that(&arg1.unwrap().exclusive_minimum)
+            .is_some()
+            .is_equal_to(&123);
+        assert_that(&arg1.unwrap().exclusive_maximum)
+            .is_some()
+            .is_equal_to(&567789);
 
         // Sanity check that min and max are none.
         assert_that(&arg1.unwrap().minimum).is_none();
@@ -147,11 +151,17 @@ fn test_bundle_parameters() {
 
         // Destination should have just path
         assert_that(&arg2.unwrap().destination.env.as_ref()).is_none();
-        assert_that(&arg2.unwrap().destination.path.as_ref()).is_some().is_equal_to(&"/path/to/num".to_string());
+        assert_that(&arg2.unwrap().destination.path.as_ref())
+            .is_some()
+            .is_equal_to(&"/path/to/num".to_string());
 
         // Test min/max
-        assert_that(&arg2.unwrap().minimum).is_some().is_equal_to(&123);
-        assert_that(&arg2.unwrap().maximum).is_some().is_equal_to(&567789);
+        assert_that(&arg2.unwrap().minimum)
+            .is_some()
+            .is_equal_to(&123);
+        assert_that(&arg2.unwrap().maximum)
+            .is_some()
+            .is_equal_to(&567789);
 
         // Sanity check that exclusive min and max are none.
         assert_that(&arg2.unwrap().exclusive_minimum).is_none();
@@ -182,15 +192,21 @@ fn test_bundle_parameters() {
         let allowed = &arg3.unwrap().allowed_values;
         assert_that(allowed).is_equal_to(&Some(vec![json!("a"), json!("ab"), json!("abc")]));
 
-        assert_that(&arg3.as_ref().unwrap().min_length).is_some().is_equal_to(1);
-        assert_that(&arg3.as_ref().unwrap().max_length).is_some().is_equal_to(5);
+        assert_that(&arg3.as_ref().unwrap().min_length)
+            .is_some()
+            .is_equal_to(1);
+        assert_that(&arg3.as_ref().unwrap().max_length)
+            .is_some()
+            .is_equal_to(5);
         assert_that(&arg3.as_ref().unwrap().pattern).is_equal_to(&Some("[a-z]+".to_string()));
         assert_that(&arg3.unwrap().required).is_true();
 
         let meta = &arg3.as_ref().unwrap().metadata;
         assert_that(&meta.as_ref()).is_some();
 
-        assert_that(&meta.as_ref().unwrap().description.as_ref()).is_some().is_equal_to(&"a parameter".to_string());
+        assert_that(&meta.as_ref().unwrap().description.as_ref())
+            .is_some()
+            .is_equal_to(&"a parameter".to_string());
 
         let apply_to = &arg3.unwrap().apply_to;
         assert_that(apply_to).is_equal_to(&Some(vec!["uninstall".to_string()]));
@@ -219,10 +235,13 @@ fn test_bundle_custom() {
 
     let bun = res.unwrap();
     assert_that(&bun.custom).is_some();
-    let val: Option<&serde_json::Value> = bun.custom.as_ref().unwrap().get(&"com.example.praxis".to_string());
+    let val: Option<&serde_json::Value> = bun
+        .custom
+        .as_ref()
+        .unwrap()
+        .get(&"com.example.praxis".to_string());
     // Lookup docs on Value when I'm online again.
     assert_that(&val).is_some(); // .map(|v| v.get("foo").is_some() );
-
 }
 
 // Test credentials
@@ -257,14 +276,22 @@ fn test_bundle_credentials() {
 
     let creds = &bun.credentials.as_ref().unwrap();
     let first = &creds.get(&"mytoken".to_string()).unwrap();
-    assert_that(&first.description).is_some().is_equal_to("token".to_string());
-    assert_that(&first.env).is_some().is_equal_to("TOKEN".to_string());
+    assert_that(&first.description)
+        .is_some()
+        .is_equal_to("token".to_string());
+    assert_that(&first.env)
+        .is_some()
+        .is_equal_to("TOKEN".to_string());
     assert_that(&first.path).is_none();
 
     let second = &creds.get(&"myconfig".to_string()).unwrap();
-    assert_that(&second.description).is_some().is_equal_to("config".to_string());
+    assert_that(&second.description)
+        .is_some()
+        .is_equal_to("config".to_string());
     assert_that(&second.env).is_none();
-    assert_that(&second.path).is_some().is_equal_to("/etc/config".to_string());
+    assert_that(&second.path)
+        .is_some()
+        .is_equal_to("/etc/config".to_string());
 
     let third = &creds.get(&"myboth".to_string()).unwrap();
     assert_that(&third.description).is_none();
@@ -328,12 +355,15 @@ fn test_bundle_images() {
         assert_that(&ii1.platform.as_ref().unwrap().arch).is_equal_to(Some("amd64".to_string()));
     }
 
-
-
     let imgs = &bun.images.as_ref();
     assert_that(&imgs.unwrap().len()).is_equal_to(1);
     {
-        let img = &bun.images.as_ref().unwrap().get(&"web".to_string()).unwrap();
+        let img = &bun
+            .images
+            .as_ref()
+            .unwrap()
+            .get(&"web".to_string())
+            .unwrap();
         assert_that(&img.image).is_equal_to("nginx:latest".to_string());
         assert_that(&img.image_type).is_equal_to(Some("oci".to_string()));
         assert_that(&img.media_type).is_equal_to(Some("application/x-image-thinger".to_string()));
@@ -343,7 +373,6 @@ fn test_bundle_images() {
     }
 }
 
-
 // Test that a parsing failure returns an error (not a panic)
 #[test]
 fn test_bundle_parse_error() {
@@ -351,7 +380,6 @@ fn test_bundle_parse_error() {
     let bun = Bundle::from_string(bad_data);
     assert_that(&bun.is_err()).is_true()
 }
-
 
 // Test loading a bundle from a file
 #[test]
@@ -364,7 +392,6 @@ fn test_bundle_deserialize() {
     assert_that(&bun.maintainers.unwrap().len()).is_equal_to(&1);
     assert_that(&bun.custom.unwrap().len()).is_equal_to(&2);
 }
-
 
 // Check that a missing file results in an error (not a panic)
 #[test]


### PR DESCRIPTION
👋

The formatting changes in this PR are 100% auto-generated by `cargo fmt` or `cargo fix --edition-idioms`. The 2018 idioms lint is now checked by the compiler, but we might also want to add `cargo fmt -- --check` to CI at some point.