### PR TITLE
Add benchmarks, use fewer "stringly typed" fields/method parameters, re-export cnab module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["cnab"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spectral = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,10 @@ maintenance = { status = "experimental" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spectral = "0.6"
+
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "bundle_serde"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,17 @@
 [package]
 name = "libcnab"
 version = "0.1.0"
+license = "MIT"
 authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
 edition = "2018"
+description = "A Rust implementation of CNAB Core 1.0-WD"
+homepage = "https://cnab.io"
+readme = "README.md"
+repository = "https://github.com/deislabs/libcnab-rust"
+keywords = ["cnab"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["cnab"]
 maintenance = { status = "experimental" }
 
 [dependencies]
+semver = { version = "0.9", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spectral = "0.6"

--- a/benches/bundle_serde.rs
+++ b/benches/bundle_serde.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate criterion;
 
-use libcnab::cnab::Bundle;
+use libcnab::Bundle;
 
 use criterion::{black_box, Benchmark, Criterion, Throughput};
 use std::fs::File;

--- a/benches/bundle_serde.rs
+++ b/benches/bundle_serde.rs
@@ -6,6 +6,7 @@ use libcnab::cnab::Bundle;
 use criterion::{black_box, Benchmark, Criterion, Throughput};
 use std::fs::File;
 use std::io::Read;
+use std::str::FromStr;
 
 fn serialize(c: &mut Criterion) {
     let mut json = String::new();
@@ -13,7 +14,7 @@ fn serialize(c: &mut Criterion) {
         .unwrap()
         .read_to_string(&mut json)
         .unwrap();
-    let bundle = Bundle::from_string(&json).unwrap();
+    let bundle = Bundle::from_str(&json).unwrap();
     let size = Throughput::Bytes(serde_json::to_string(&bundle).unwrap().len() as u32);
 
     c.bench(
@@ -36,7 +37,7 @@ fn deserialize(c: &mut Criterion) {
     c.bench(
         "Bundle",
         Benchmark::new("deserialize", move |b| {
-            b.iter(|| Bundle::from_string(black_box(&json)).unwrap())
+            b.iter(|| Bundle::from_str(black_box(&json)).unwrap())
         })
         .throughput(size),
     );

--- a/benches/bundle_serde.rs
+++ b/benches/bundle_serde.rs
@@ -1,0 +1,46 @@
+#[macro_use]
+extern crate criterion;
+
+use libcnab::cnab::Bundle;
+
+use criterion::{black_box, Benchmark, Criterion, Throughput};
+use std::fs::File;
+use std::io::Read;
+
+fn serialize(c: &mut Criterion) {
+    let mut json = String::new();
+    File::open("./testdata/bundle.json")
+        .unwrap()
+        .read_to_string(&mut json)
+        .unwrap();
+    let bundle = Bundle::from_string(&json).unwrap();
+    let size = Throughput::Bytes(serde_json::to_string(&bundle).unwrap().len() as u32);
+
+    c.bench(
+        "Bundle",
+        Benchmark::new("serialize", move |b| {
+            b.iter(|| serde_json::to_string(black_box(&bundle)).unwrap())
+        })
+        .throughput(size),
+    );
+}
+
+fn deserialize(c: &mut Criterion) {
+    let mut json = String::new();
+    File::open("./testdata/bundle.json")
+        .unwrap()
+        .read_to_string(&mut json)
+        .unwrap();
+    let size = Throughput::Bytes(json.len() as u32);
+
+    c.bench(
+        "Bundle",
+        Benchmark::new("deserialize", move |b| {
+            b.iter(|| Bundle::from_string(black_box(&json)).unwrap())
+        })
+        .throughput(size),
+    );
+}
+
+criterion_group!(benches, serialize, deserialize);
+criterion_main!(benches);

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 /// Bundle implements a CNAB bundle descriptor
@@ -166,7 +166,7 @@ pub struct Credential {
     /// The name of the environment variable into which the value will be placed
     pub env: Option<String>,
     /// The fully qualified path into which the value will be placed
-    pub path: Option<String>,
+    pub path: Option<PathBuf>,
 }
 
 /// Parameter describes a parameter that will be put into the invocation image
@@ -263,5 +263,5 @@ pub struct Destination {
     /// The name of the destination environment variable
     pub env: Option<String>,
     /// The fully qualified path to the destination file
-    pub path: Option<String>,
+    pub path: Option<PathBuf>,
 }

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -1,3 +1,4 @@
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
@@ -53,22 +54,21 @@ pub struct Bundle {
     /// schema_version is the version of the CNAB specification used to describe this
     pub schema_version: String,
     /// version is the version of the bundle
-    pub version: String,
+    pub version: Version,
 }
 
 /// Represents a bundle.
 impl Bundle {
-    ///fn new(name: String, version: String) -> Bundle {}
-    pub fn from_string(json_data: &str) -> Result<Bundle, serde_json::Error> {
+    ///fn new(name: String, version: Version) -> Bundle {}
+    pub fn from_string(json_data: &str) -> Result<Self, serde_json::Error> {
         let res: Bundle = serde_json::from_str(json_data)?;
         Ok(res)
     }
 
-    pub fn from_file(file_path: &str) -> Result<Bundle, BundleParseError> {
+    pub fn from_file(file_path: &str) -> Result<Self, BundleParseError> {
         let file = File::open(Path::new(&file_path))?;
         let buf = std::io::BufReader::new(file);
-        let res: Bundle = serde_json::from_reader(buf)?;
-        Ok(res)
+        Ok(serde_json::from_reader(buf)?)
     }
 }
 

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -78,7 +78,7 @@ impl Bundle {
 #[derive(Debug)]
 pub enum BundleParseError {
     SerdeJSONError(serde_json::Error),
-    IoError(std::io::Error)
+    IoError(std::io::Error),
 }
 
 impl From<std::io::Error> for BundleParseError {
@@ -88,12 +88,12 @@ impl From<std::io::Error> for BundleParseError {
 }
 
 impl From<serde_json::Error> for BundleParseError {
-    fn from(error: serde_json::Error) -> Self{
+    fn from(error: serde_json::Error) -> Self {
         BundleParseError::SerdeJSONError(error)
     }
 }
 
-/// Maintainer describes a bundle mainainer.
+/// Maintainer describes a bundle maintainer.
 ///
 /// The name field is required, though the format of its value is unspecified.
 #[derive(Debug, Serialize, Deserialize)]
@@ -179,7 +179,7 @@ pub struct Parameter {
     pub exclusive_minimum: Option<i64>,
     /// The maximum
     ///
-    /// If unspecieid, the maximum 64-bit integer value is applied
+    /// If unspecified, the maximum 64-bit integer value is applied
     pub maximum: Option<i64>,
     /// The maximum length of a string value
     ///
@@ -221,7 +221,7 @@ pub struct Action {
     /// If true, this action does not require any state information to be injected
     ///
     /// For example, printing help text does not require an installation, credentials,
-    /// or paramters.
+    /// or parameters.
     #[serde(default)]
     pub stateless: bool,
 }
@@ -233,11 +233,11 @@ pub struct Metadata {
     pub description: Option<String>,
 }
 
-/// Destination describes where, in the invocation image, a particular paramter value should be
+/// Destination describes where, in the invocation image, a particular parameter value should be
 /// placed.
 ///
 /// A parameter value can be placed into an environment variable (`env`) or a file at
-/// a particular location on the filesystem (`path`). This is a non-exclusive or, meaining
+/// a particular location on the filesystem (`path`). This is a non-exclusive or, meaning
 /// that the same paramter can be written to both an env var and a path.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Destination {

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 ///
 /// Bundle descriptors describe the properties of a bundle, including which images
 /// are associated, what parameters and credentials are configurable, and whether there
-/// are any additional traget actions that can be executed on this bundle.
+/// are any additional target actions that can be executed on this bundle.
 ///
 /// The fields here are in canonical order.
 #[derive(Debug, Serialize, Deserialize)]
@@ -64,7 +64,7 @@ impl Bundle {
     /// A convenience function to open and deserialize a [`bundle.json`](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md) file.
     ///
     /// ```
-    /// use libcnab::cnab::Bundle;
+    /// use libcnab::Bundle;
     ///
     /// let bundle = Bundle::from_file("testdata/bundle.json").unwrap();
     /// assert_eq!(bundle.name, "helloworld");

--- a/src/cnab.rs
+++ b/src/cnab.rs
@@ -2,7 +2,9 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::Read;
 use std::path::Path;
+use std::str::FromStr;
 
 /// Bundle implements a CNAB bundle descriptor
 ///
@@ -59,16 +61,32 @@ pub struct Bundle {
 
 /// Represents a bundle.
 impl Bundle {
-    ///fn new(name: String, version: Version) -> Bundle {}
-    pub fn from_string(json_data: &str) -> Result<Self, serde_json::Error> {
-        let res: Bundle = serde_json::from_str(json_data)?;
-        Ok(res)
+    /// A convenience function to open and deserialize a [`bundle.json`](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md) file.
+    ///
+    /// ```
+    /// use libcnab::cnab::Bundle;
+    ///
+    /// let bundle = Bundle::from_file("testdata/bundle.json").unwrap();
+    /// assert_eq!(bundle.name, "helloworld");
+    /// ```
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, BundleParseError> {
+        let file = File::open(path)?;
+        Self::from_json(file)
     }
 
-    pub fn from_file(file_path: &str) -> Result<Self, BundleParseError> {
-        let file = File::open(Path::new(&file_path))?;
-        let buf = std::io::BufReader::new(file);
-        Ok(serde_json::from_reader(buf)?)
+    /// Deserialize a `Bundle` from any type implementing `Read`.
+    pub fn from_json<R: Read>(reader: R) -> Result<Self, BundleParseError> {
+        let bundle = serde_json::from_reader(reader)?;
+        Ok(bundle)
+    }
+}
+
+impl FromStr for Bundle {
+    type Err = serde_json::Error;
+
+    fn from_str(json_data: &str) -> Result<Self, Self::Err> {
+        let bundle = serde_json::from_str(json_data)?;
+        Ok(bundle)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(test, deny(warnings))]
 #![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate serde_derive;
-
 pub mod cnab;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(test, deny(warnings))]
 #![warn(rust_2018_idioms)]
 
-pub mod cnab;
+mod cnab;
+pub use crate::cnab::*;
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-extern crate serde;
+#![cfg_attr(test, deny(warnings))]
+#![warn(rust_2018_idioms)]
+
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 
 pub mod cnab;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,3 @@
-extern crate spectral;
-
 use crate::cnab::Bundle;
 use serde_json::*;
 use spectral::prelude::*;
@@ -125,12 +123,18 @@ fn test_bundle_parameters() {
         assert_that(&arg1.unwrap().required).is_false();
 
         // Destination should have just env
-        assert_that(&arg1.unwrap().destination.env.as_ref()).is_some().is_equal_to(&"FIRST".to_string());
+        assert_that(&arg1.unwrap().destination.env.as_ref())
+            .is_some()
+            .is_equal_to(&"FIRST".to_string());
         assert_that(&arg1.unwrap().destination.path).is_none();
 
         // Test exclusive_min/max
-        assert_that(&arg1.unwrap().exclusive_minimum).is_some().is_equal_to(&123);
-        assert_that(&arg1.unwrap().exclusive_maximum).is_some().is_equal_to(&567789);
+        assert_that(&arg1.unwrap().exclusive_minimum)
+            .is_some()
+            .is_equal_to(&123);
+        assert_that(&arg1.unwrap().exclusive_maximum)
+            .is_some()
+            .is_equal_to(&567789);
 
         // Sanity check that min and max are none.
         assert_that(&arg1.unwrap().minimum).is_none();
@@ -147,11 +151,17 @@ fn test_bundle_parameters() {
 
         // Destination should have just path
         assert_that(&arg2.unwrap().destination.env.as_ref()).is_none();
-        assert_that(&arg2.unwrap().destination.path.as_ref()).is_some().is_equal_to(&"/path/to/num".to_string());
+        assert_that(&arg2.unwrap().destination.path.as_ref())
+            .is_some()
+            .is_equal_to(&"/path/to/num".to_string());
 
         // Test min/max
-        assert_that(&arg2.unwrap().minimum).is_some().is_equal_to(&123);
-        assert_that(&arg2.unwrap().maximum).is_some().is_equal_to(&567789);
+        assert_that(&arg2.unwrap().minimum)
+            .is_some()
+            .is_equal_to(&123);
+        assert_that(&arg2.unwrap().maximum)
+            .is_some()
+            .is_equal_to(&567789);
 
         // Sanity check that exclusive min and max are none.
         assert_that(&arg2.unwrap().exclusive_minimum).is_none();
@@ -182,15 +192,21 @@ fn test_bundle_parameters() {
         let allowed = &arg3.unwrap().allowed_values;
         assert_that(allowed).is_equal_to(&Some(vec![json!("a"), json!("ab"), json!("abc")]));
 
-        assert_that(&arg3.as_ref().unwrap().min_length).is_some().is_equal_to(1);
-        assert_that(&arg3.as_ref().unwrap().max_length).is_some().is_equal_to(5);
+        assert_that(&arg3.as_ref().unwrap().min_length)
+            .is_some()
+            .is_equal_to(1);
+        assert_that(&arg3.as_ref().unwrap().max_length)
+            .is_some()
+            .is_equal_to(5);
         assert_that(&arg3.as_ref().unwrap().pattern).is_equal_to(&Some("[a-z]+".to_string()));
         assert_that(&arg3.unwrap().required).is_true();
 
         let meta = &arg3.as_ref().unwrap().metadata;
         assert_that(&meta.as_ref()).is_some();
 
-        assert_that(&meta.as_ref().unwrap().description.as_ref()).is_some().is_equal_to(&"a parameter".to_string());
+        assert_that(&meta.as_ref().unwrap().description.as_ref())
+            .is_some()
+            .is_equal_to(&"a parameter".to_string());
 
         let apply_to = &arg3.unwrap().apply_to;
         assert_that(apply_to).is_equal_to(&Some(vec!["uninstall".to_string()]));
@@ -219,10 +235,13 @@ fn test_bundle_custom() {
 
     let bun = res.unwrap();
     assert_that(&bun.custom).is_some();
-    let val: Option<&serde_json::Value> = bun.custom.as_ref().unwrap().get(&"com.example.praxis".to_string());
+    let val: Option<&serde_json::Value> = bun
+        .custom
+        .as_ref()
+        .unwrap()
+        .get(&"com.example.praxis".to_string());
     // Lookup docs on Value when I'm online again.
     assert_that(&val).is_some(); // .map(|v| v.get("foo").is_some() );
-
 }
 
 // Test credentials
@@ -257,14 +276,22 @@ fn test_bundle_credentials() {
 
     let creds = &bun.credentials.as_ref().unwrap();
     let first = &creds.get(&"mytoken".to_string()).unwrap();
-    assert_that(&first.description).is_some().is_equal_to("token".to_string());
-    assert_that(&first.env).is_some().is_equal_to("TOKEN".to_string());
+    assert_that(&first.description)
+        .is_some()
+        .is_equal_to("token".to_string());
+    assert_that(&first.env)
+        .is_some()
+        .is_equal_to("TOKEN".to_string());
     assert_that(&first.path).is_none();
 
     let second = &creds.get(&"myconfig".to_string()).unwrap();
-    assert_that(&second.description).is_some().is_equal_to("config".to_string());
+    assert_that(&second.description)
+        .is_some()
+        .is_equal_to("config".to_string());
     assert_that(&second.env).is_none();
-    assert_that(&second.path).is_some().is_equal_to("/etc/config".to_string());
+    assert_that(&second.path)
+        .is_some()
+        .is_equal_to("/etc/config".to_string());
 
     let third = &creds.get(&"myboth".to_string()).unwrap();
     assert_that(&third.description).is_none();
@@ -328,12 +355,15 @@ fn test_bundle_images() {
         assert_that(&ii1.platform.as_ref().unwrap().arch).is_equal_to(Some("amd64".to_string()));
     }
 
-
-
     let imgs = &bun.images.as_ref();
     assert_that(&imgs.unwrap().len()).is_equal_to(1);
     {
-        let img = &bun.images.as_ref().unwrap().get(&"web".to_string()).unwrap();
+        let img = &bun
+            .images
+            .as_ref()
+            .unwrap()
+            .get(&"web".to_string())
+            .unwrap();
         assert_that(&img.image).is_equal_to("nginx:latest".to_string());
         assert_that(&img.image_type).is_equal_to(Some("oci".to_string()));
         assert_that(&img.media_type).is_equal_to(Some("application/x-image-thinger".to_string()));
@@ -343,7 +373,6 @@ fn test_bundle_images() {
     }
 }
 
-
 // Test that a parsing failure returns an error (not a panic)
 #[test]
 fn test_bundle_parse_error() {
@@ -351,7 +380,6 @@ fn test_bundle_parse_error() {
     let bun = Bundle::from_string(bad_data);
     assert_that(&bun.is_err()).is_true()
 }
-
 
 // Test loading a bundle from a file
 #[test]
@@ -364,7 +392,6 @@ fn test_bundle_deserialize() {
     assert_that(&bun.maintainers.unwrap().len()).is_equal_to(&1);
     assert_that(&bun.custom.unwrap().len()).is_equal_to(&2);
 }
-
 
 // Check that a missing file results in an error (not a panic)
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::cnab::Bundle;
+use semver::Version;
 use serde_json::*;
 use spectral::prelude::*;
 
@@ -18,7 +19,7 @@ fn test_bundle_simple() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
     assert_that(&bun.invocation_images.len()).is_equal_to(&0);
 }
 
@@ -39,7 +40,7 @@ fn test_bundle_keywords() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
     assert_that(&bun.invocation_images.len()).is_equal_to(&0);
 
     let kw = &bun.keywords.unwrap();
@@ -109,7 +110,7 @@ fn test_bundle_parameters() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
 
     let params = bun.parameters.unwrap();
     assert_that(&params.len()).is_equal_to(&3);
@@ -340,7 +341,7 @@ fn test_bundle_images() {
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("1.0.0".to_string());
+    assert_that(&bun.version).is_equal_to(Version::new(1, 0, 0));
 
     // Check that all of the fields unmarshaled correctly.
     let invo_imgs = &bun.invocation_images;
@@ -388,7 +389,7 @@ fn test_bundle_deserialize() {
 
     assert_that(&bun.name).is_equal_to("helloworld".to_string());
     assert_that(&bun.schema_version).is_equal_to("v1.0.0-WD".to_string());
-    assert_that(&bun.version).is_equal_to("0.1.2".to_string());
+    assert_that(&bun.version).is_equal_to(Version::new(0, 1, 2));
     assert_that(&bun.maintainers.unwrap().len()).is_equal_to(&1);
     assert_that(&bun.custom.unwrap().len()).is_equal_to(&2);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -145,10 +145,11 @@ fn test_bundle_parameters() {
         assert_that(&arg2.unwrap().required).is_true();
 
         // Destination should have just path
-        assert_that(&arg2.unwrap().destination.env.as_ref()).is_none();
-        assert_that(&arg2.unwrap().destination.path.as_ref())
+        let destination = &arg2.unwrap().destination;
+        assert_that(&destination.env.as_ref()).is_none();
+        assert_that(&destination.path)
             .is_some()
-            .is_equal_to(&"/path/to/num".to_string());
+            .is_equal_to("/path/to/num".parse::<std::path::PathBuf>().unwrap());
 
         // Test min/max
         assert_that(&arg2.unwrap().minimum)
@@ -178,7 +179,9 @@ fn test_bundle_parameters() {
         assert_that(&env).is_equal_to(&Some("LETTERS".to_string()));
 
         let path = &dest.path;
-        assert_that(path).is_equal_to(&Some("/path/to/abc".to_string()));
+        assert_that(path)
+            .is_some()
+            .is_equal_to("/path/to/abc".parse::<std::path::PathBuf>().unwrap());
 
         let abc = json!("abc");
         let dv = &arg3.unwrap().default_value;
@@ -281,7 +284,7 @@ fn test_bundle_credentials() {
     assert_that(&second.env).is_none();
     assert_that(&second.path)
         .is_some()
-        .is_equal_to("/etc/config".to_string());
+        .is_equal_to("/etc/config".parse::<std::path::PathBuf>().unwrap());
 
     let third = &creds.get(&"myboth".to_string()).unwrap();
     assert_that(&third.description).is_none();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::cnab::Bundle;
+use crate::cnab::*;
 use semver::Version;
 use serde_json::*;
 use spectral::prelude::*;
@@ -6,16 +6,14 @@ use spectral::prelude::*;
 #[test]
 // Testing that we can build one with only the minimal fields.
 fn test_bundle_simple() {
-    let res = Bundle::from_string(
-        r#"{
+    let bun: Bundle = r#"{
         "name": "aristotle",
         "invocationImages": [],
         "schemaVersion": "1.0-WD",
         "version": "1.0.0"
-    }"#,
-    );
-
-    let bun = res.unwrap();
+    }"#
+    .parse()
+    .unwrap();
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
@@ -26,17 +24,15 @@ fn test_bundle_simple() {
 // Test labels
 #[test]
 fn test_bundle_keywords() {
-    let res = Bundle::from_string(
-        r#"{
+    let bun: Bundle = r#"{
         "name": "aristotle",
         "invocationImages": [],
         "schemaVersion": "1.0-WD",
         "version": "1.0.0",
         "keywords": ["a", "b", "c"]
-    }"#,
-    );
-
-    let bun = res.unwrap();
+    }"#
+    .parse()
+    .unwrap();
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
@@ -53,8 +49,7 @@ fn test_bundle_keywords() {
 // Test parameters
 #[test]
 fn test_bundle_parameters() {
-    let res = Bundle::from_string(
-        r#"{
+    let bun: Bundle = r#"{
         "name": "aristotle",
         "invocationImages": [],
         "schemaVersion": "1.0-WD",
@@ -103,10 +98,9 @@ fn test_bundle_parameters() {
                 "type": "string"
             }
         }
-    }"#,
-    );
-
-    let bun = res.unwrap();
+    }"#
+    .parse()
+    .unwrap();
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
@@ -218,8 +212,7 @@ fn test_bundle_parameters() {
 // Test custom data
 #[test]
 fn test_bundle_custom() {
-    let res = Bundle::from_string(
-        r#"{
+    let bun: Bundle = r#"{
         "name": "aristotle",
         "invocationImages": [],
         "schemaVersion": "1.0.0",
@@ -229,12 +222,10 @@ fn test_bundle_custom() {
             "techne": true
           }
         }
-    }"#,
-    );
+    }"#
+    .parse()
+    .unwrap();
 
-    assert_that(&res).is_ok();
-
-    let bun = res.unwrap();
     assert_that(&bun.custom).is_some();
     let val: Option<&serde_json::Value> = bun
         .custom
@@ -248,8 +239,7 @@ fn test_bundle_custom() {
 // Test credentials
 #[test]
 fn test_bundle_credentials() {
-    let res = Bundle::from_string(
-        r#"{
+    let bun: Bundle = r#"{
         "name": "aristotle",
         "invocationImages": [],
         "schemaVersion": "1.0-WD",
@@ -268,10 +258,9 @@ fn test_bundle_credentials() {
                 "env": "FOO"
             }
         }
-    }"#,
-    );
-
-    let bun = res.unwrap();
+    }"#
+    .parse()
+    .unwrap();
 
     assert_that(&bun.credentials.as_ref()).is_some();
 
@@ -304,8 +293,7 @@ fn test_bundle_credentials() {
 #[test]
 fn test_bundle_images() {
     // Testing that we can build one with only the minimal fields.
-    let res = Bundle::from_string(
-        r#"{
+    let bun: Bundle = r#"{
         "name": "aristotle",
         "images": {
             "web": {
@@ -334,10 +322,9 @@ fn test_bundle_images() {
         "schemaVersion": "1.0-WD",
         "version": "1.0.0",
         "labels": ["hello", "world"]
-    }"#,
-    );
-
-    let bun = res.unwrap();
+    }"#
+    .parse()
+    .unwrap();
 
     assert_that(&bun.name).is_equal_to("aristotle".to_string());
     assert_that(&bun.schema_version).is_equal_to("1.0-WD".to_string());
@@ -378,7 +365,7 @@ fn test_bundle_images() {
 #[test]
 fn test_bundle_parse_error() {
     let bad_data = "{hello";
-    let bun = Bundle::from_string(bad_data);
+    let bun = bad_data.parse::<Bundle>();
     assert_that(&bun.is_err()).is_true()
 }
 


### PR DESCRIPTION
Depends on #12 (before merge see diff for this PR alone here: https://github.com/jlegrone/libcnab-rust/compare/feature/fix-edition-idioms...jlegrone:feature/less-stringly-typed)

### In this PR

1. Switches `Bundle` version field to [Version](https://docs.rs/semver/0.9.0/semver/struct.Version.html)
2. Switches `Destination` and `Credential` path fields to [PathBuf](https://doc.rust-lang.org/std/path/struct.PathBuf.html)
3. Implements the [FromStr](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for `Bundle`
    - enables things like `let bundle: Bundle = mystring.parse().unwrap()`
4. Adds a function `Bundle::from_json` which is generic over types that implement [Read](https://doc.rust-lang.org/std/io/trait.Read.html)
5. Closes https://github.com/deislabs/libcnab-rust/issues/11 by making exports available at the top level of the crate: <img width="995" alt="Screen Shot 2019-05-18 at 6 00 47 PM" src="https://user-images.githubusercontent.com/6752382/57975426-e7a64680-7996-11e9-9d56-8505660bf510.png">
6. Adds benchmarks for serializing/deserializing Bundles.

To see how performance is impacted by each commit since e3ada62, run:

```
git rebase --interactive --exec "git rev-parse HEAD && cargo bench --bench bundle_serde" e3ada62
```

<details>
<summary>Benchmark output from my machine</summary>

```
Executing: git rev-parse HEAD && cargo bench --bench bundle_serde
92a633fd2f58b87e5434bbcfcc210921689a2afe
   Compiling libcnab v0.1.0 (/Users/jacob.legrone/Development/libcnab-rust)
    Finished release [optimized] target(s) in 10.71s
     Running target/release/deps/bundle_serde-b5d012519f913f03
Bundle/serialize        time:   [2.7536 us 2.7729 us 2.7958 us]
                        thrpt:  [414.11 MiB/s 417.52 MiB/s 420.46 MiB/s]
                 change:
                        time:   [-0.9231% +0.4749% +1.9534%] (p = 0.54 > 0.05)
                        thrpt:  [-1.9159% -0.4727% +0.9317%]
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

Bundle/deserialize      time:   [6.8401 us 6.9478 us 7.0688 us]
                        thrpt:  [200.48 MiB/s 203.97 MiB/s 207.18 MiB/s]
                 change:
                        time:   [+1.6930% +4.1975% +6.5885%] (p = 0.00 < 0.05)
                        thrpt:  [-6.1813% -4.0284% -1.6648%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Executing: git rev-parse HEAD && cargo bench --bench bundle_serde
dc96e879f7d983cca14cf7922cdbe5804f2133d1
    Updating crates.io index
   Compiling libcnab v0.1.0 (/Users/jacob.legrone/Development/libcnab-rust)
    Finished release [optimized] target(s) in 11.19s
     Running target/release/deps/bundle_serde-7e52979aadfa5064
Bundle/serialize        time:   [2.9274 us 2.9483 us 2.9705 us]
                        thrpt:  [389.75 MiB/s 392.69 MiB/s 395.50 MiB/s]
                 change:
                        time:   [+3.1778% +4.8297% +6.3520%] (p = 0.00 < 0.05)
                        thrpt:  [-5.9726% -4.6072% -3.0799%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

Bundle/deserialize      time:   [6.7073 us 6.7609 us 6.8189 us]
                        thrpt:  [207.83 MiB/s 209.61 MiB/s 211.29 MiB/s]
                 change:
                        time:   [-3.9089% -1.7726% +0.2097%] (p = 0.12 > 0.05)
                        thrpt:  [-0.2093% +1.8046% +4.0679%]
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe

Executing: git rev-parse HEAD && cargo bench --bench bundle_serde
b645f3685ac58ba964035541484ada71fa1ea0e1
   Compiling libcnab v0.1.0 (/Users/jacob.legrone/Development/libcnab-rust)
    Finished release [optimized] target(s) in 6.52s
     Running target/release/deps/bundle_serde-7e52979aadfa5064
Bundle/serialize        time:   [2.8990 us 2.9261 us 2.9577 us]
                        thrpt:  [391.45 MiB/s 395.67 MiB/s 399.37 MiB/s]
                 change:
                        time:   [-1.3754% -0.0355% +1.4400%] (p = 0.96 > 0.05)
                        thrpt:  [-1.4196% +0.0356% +1.3946%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

Bundle/deserialize      time:   [6.6332 us 6.6790 us 6.7317 us]
                        thrpt:  [210.52 MiB/s 212.18 MiB/s 213.64 MiB/s]
                 change:
                        time:   [-1.8580% +0.2321% +2.2868%] (p = 0.83 > 0.05)
                        thrpt:  [-2.2357% -0.2316% +1.8932%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

Executing: git rev-parse HEAD && cargo bench --bench bundle_serde
7325df12334a9db64a01dc2097fb98d4f1722137
   Compiling libcnab v0.1.0 (/Users/jacob.legrone/Development/libcnab-rust)
    Finished release [optimized] target(s) in 6.57s
     Running target/release/deps/bundle_serde-7e52979aadfa5064
Bundle/serialize        time:   [2.9532 us 2.9700 us 2.9895 us]
                        thrpt:  [387.27 MiB/s 389.81 MiB/s 392.03 MiB/s]
                 change:
                        time:   [-0.2478% +1.1851% +2.5554%] (p = 0.10 > 0.05)
                        thrpt:  [-2.4918% -1.1712% +0.2484%]
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

Bundle/deserialize      time:   [6.5337 us 6.5781 us 6.6302 us]
                        thrpt:  [213.74 MiB/s 215.44 MiB/s 216.90 MiB/s]
                 change:
                        time:   [-3.9119% -1.8029% +0.3983%] (p = 0.12 > 0.05)
                        thrpt:  [-0.3968% +1.8360% +4.0712%]
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

Executing: git rev-parse HEAD && cargo bench --bench bundle_serde
0de95863c41fe751059628cb1fe1b3b7b440c947
   Compiling libcnab v0.1.0 (/Users/jacob.legrone/Development/libcnab-rust)
    Finished release [optimized] target(s) in 6.61s
     Running target/release/deps/bundle_serde-7e52979aadfa5064
Bundle/serialize        time:   [2.9073 us 2.9290 us 2.9521 us]
                        thrpt:  [392.19 MiB/s 395.28 MiB/s 398.22 MiB/s]
                 change:
                        time:   [-2.4627% -1.2536% -0.1013%] (p = 0.04 < 0.05)
                        thrpt:  [+0.1014% +1.2695% +2.5249%]
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

Bundle/deserialize      time:   [6.6034 us 6.6636 us 6.7415 us]
                        thrpt:  [210.22 MiB/s 212.67 MiB/s 214.61 MiB/s]
                 change:
                        time:   [-0.7378% +1.4958% +4.0906%] (p = 0.21 > 0.05)
                        thrpt:  [-3.9299% -1.4738% +0.7432%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
```

</details>