### PR TITLE
chore(Cargo.toml): update repo name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 description = "A Rust implementation of CNAB Core 1.0 final draft"
 homepage = "https://cnab.io"
 readme = "README.md"
-repository = "https://github.com/deislabs/libcnab-rust"
+repository = "https://github.com/cnabio/cnab-rs"
 keywords = ["cnab"]
 
 [badges]


### PR DESCRIPTION
Repo name changed; updating the Cargo.toml accordingly.

Closes https://github.com/cnabio/libcnab-rust/issues/27